### PR TITLE
Improve X scraper resilience

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -1,2 +1,2 @@
 requests
-snscrape
+snscrape @ git+https://github.com/JustAnotherArchivist/snscrape@master

--- a/scraper.json
+++ b/scraper.json
@@ -6,12 +6,19 @@
     "skip_media_posts": true,
     "thread_depth_limit": 50,
     "nitter_instances": [
-      "https://nitter.net",
+      "https://xcancel.com",
+      "https://nitter.poast.org",
+      "https://nitter.privacyredirect.com",
+      "https://lightbrd.com",
+      "https://nitter.space",
+      "https://nitter.tiekoetter.com",
+      "https://nuku.trabun.org",
       "https://nitter.fdn.fr",
-      "https://nitter.lacontrevoie.fr"
+      "https://nitter.lacontrevoie.fr",
+      "https://nitter.net"
     ],
-    "request_timeout": 10,
-    "max_retries": 2
+    "request_timeout": 15,
+    "max_retries": 6
   },
   "reddit": {
     "primary": "reddit_json",

--- a/scrapers/x/fallback_scraper.py
+++ b/scrapers/x/fallback_scraper.py
@@ -2,10 +2,27 @@
 from __future__ import annotations
 
 import datetime as dt
+import logging
 import random
-from typing import Any, Dict, List, Optional
+import time
+from typing import Any, Dict, List
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+_LOGGER = logging.getLogger(__name__)
+
+_USER_AGENTS = [
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+]
+
+
+def _random_user_agent() -> str:
+    return random.choice(_USER_AGENTS)
 
 
 class NitterClient:
@@ -21,32 +38,75 @@ class NitterClient:
         self.timeout = timeout
         self.max_retries = max_retries
 
+    def _build_session(self) -> requests.Session:
+        retry = Retry(
+            total=self.max_retries,
+            backoff_factor=0.6,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=["GET"],
+            respect_retry_after_header=True,
+            raise_on_status=False,
+        )
+        session = requests.Session()
+        session.mount("https://", HTTPAdapter(max_retries=retry))
+        session.mount("http://", HTTPAdapter(max_retries=retry))
+        return session
+
     def fetch_user(self, username: str, limit: int = 50, skip_media: bool = False) -> Dict[str, Any]:
-        for attempt in range(self.max_retries):
-            base = random.choice(self.instances)
-            params = {"max": limit}
-            try:
-                response = requests.get(
-                    f"{base.rstrip('/')}/api/user/{username.strip('@')}",
-                    params=params,
-                    timeout=self.timeout,
-                    headers={"User-Agent": "Mozilla/5.0 (compatible; scraper-bot/1.0)"},
-                )
-                response.raise_for_status()
-                payload = response.json()
-                items = self._normalize_payload(payload, skip_media=skip_media)
-                return {
-                    "platform": "x",
-                    "account": username,
-                    "scraped_at": dt.datetime.utcnow().isoformat(),
-                    "items": items,
-                    "source": "nitter",
-                    "instance": base,
-                }
-            except Exception:
-                if attempt == self.max_retries - 1:
-                    raise
-        raise RuntimeError("Unable to fetch data from Nitter instances")
+        params = {"max": max(limit, 1)}
+        errors: List[str] = []
+
+        with self._build_session() as session:
+            for base in random.sample(self.instances, k=len(self.instances)):
+                url = f"{base.rstrip('/')}/api/user/{username.strip('@')}"
+                try:
+                    response = session.get(
+                        url,
+                        params=params,
+                        timeout=self.timeout,
+                        headers={
+                            "User-Agent": _random_user_agent(),
+                            "Accept": "application/json",
+                        },
+                    )
+
+                    if response.status_code == 429:
+                        retry_after = response.headers.get("Retry-After")
+                        sleep_for = 1.0
+                        if retry_after is not None:
+                            try:
+                                sleep_for = min(8.0, float(retry_after))
+                            except ValueError:
+                                _LOGGER.debug("Invalid Retry-After header '%s' from %s", retry_after, base)
+                        errors.append(f"{base}: rate limited (429)")
+                        _LOGGER.debug("Instance %s hit rate limit, sleeping %.2fs", base, sleep_for)
+                        time.sleep(sleep_for)
+                        continue
+
+                    response.raise_for_status()
+                    payload = response.json()
+                    items = self._normalize_payload(payload, skip_media=skip_media)
+                    return {
+                        "platform": "x",
+                        "account": username,
+                        "scraped_at": dt.datetime.utcnow().isoformat(),
+                        "items": items,
+                        "source": "nitter",
+                        "instance": base,
+                    }
+                except requests.RequestException as exc:
+                    message = f"{base}: {exc}"
+                    errors.append(message)
+                    _LOGGER.debug("Request to %s failed: %s", base, exc)
+                    continue
+                except ValueError as exc:
+                    errors.append(f"{base}: invalid JSON ({exc})")
+                    _LOGGER.debug("JSON parsing failed from %s: %s", base, exc)
+                    continue
+
+        raise RuntimeError(
+            "Unable to fetch data from Nitter instances; attempts: " + ", ".join(errors)
+        )
 
     def _normalize_payload(self, payload: Dict[str, Any], skip_media: bool) -> List[Dict[str, Any]]:
         tweets: List[Dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- strengthen the Nitter fallback client with retry-aware sessions, user-agent rotation, and rate-limit handling
- expand the X scraper configuration with a larger pool of public Nitter instances and higher timeout/retry ceilings
- pin snscrape to the GitHub master branch to pick up the latest Twitter fixes

## Testing
- python -m compileall scrapers scraepr_test1.py

------
https://chatgpt.com/codex/tasks/task_e_68e2adf5cb5c8332a44e8bd068597851