### PR TITLE
Add downstream Content Opportunity Pipeline agents

### DIFF
--- a/crews/content_opportunity_pipeline/README.md
+++ b/crews/content_opportunity_pipeline/README.md
@@ -12,3 +12,29 @@ The Data Triage Agent is the first stage of the pipeline. It:
 - Exports a `Cleaned_Content_Stream` payload using `reddit_dataset_exporter`.
 
 All transformations are executed by tools so the language model never reads raw JSON directly.
+
+## Trend Analysis Agent
+
+The Trend Analysis Agent converts the `Cleaned_Content_Stream` into an `Identified_Trends_Report`:
+
+- Clusters semantically similar posts to surface potential topic clusters.
+- Calculates trend velocity and acceleration to highlight emerging signals.
+- Labels overall sentiment, recognises key opinion leaders and tags lifecycle stages.
+- Uses the `reddit_dataset_lookup` tool to inspect representative Reddit posts as needed.
+
+## Brand Alignment Agent
+
+The Brand Alignment Agent evaluates trend clusters against the JustKa AI brand guardrails:
+
+- Cross-references the Brand Core Knowledge Base to score relevance and ICP alignment.
+- Assigns funnel stages (TOFU/MOFU/BOFU) and performs qualitative risk assessments.
+- Emits a `ScoredAndFilteredOpportunities` structure that preserves key momentum metrics.
+- Leverages `reddit_dataset_lookup` to pull context for in-depth audience analysis.
+
+## Topic Curator Agent
+
+The Topic Curator Agent turns the highest value opportunities into production-ready briefs:
+
+- Prioritises 1–3 standout topics using strategic impact and urgency signals.
+- Generates 3–5 on-brand editorial angles per topic and documents supporting insights.
+- Outputs a `PrioritizedTopicBrief` JSON payload consumable by downstream planners.

--- a/crews/content_opportunity_pipeline/__init__.py
+++ b/crews/content_opportunity_pipeline/__init__.py
@@ -1,5 +1,15 @@
 """Content Opportunity Pipeline package."""
 
-from .agents import build_data_triage_agent
+from .agents import (
+    build_brand_alignment_agent,
+    build_data_triage_agent,
+    build_topic_curator_agent,
+    build_trend_analysis_agent,
+)
 
-__all__ = ["build_data_triage_agent"]
+__all__ = [
+    "build_data_triage_agent",
+    "build_trend_analysis_agent",
+    "build_brand_alignment_agent",
+    "build_topic_curator_agent",
+]

--- a/crews/content_opportunity_pipeline/agents.py
+++ b/crews/content_opportunity_pipeline/agents.py
@@ -7,6 +7,7 @@ from crewai.llm import LLM
 from .tools import (
     reddit_dataset_export_tool,
     reddit_dataset_filter_tool,
+    reddit_dataset_lookup_tool,
     reddit_scrape_loader_tool,
     reddit_scrape_locator_tool,
 )
@@ -42,6 +43,89 @@ def build_data_triage_agent() -> Agent:
             reddit_dataset_filter_tool,
             reddit_dataset_export_tool,
         ],
+        allow_delegation=False,
+        verbose=True,
+    )
+
+
+def build_trend_analysis_agent() -> Agent:
+    """Create the Trend Analysis Agent responsible for clustering and momentum scoring."""
+
+    llm = LLM(
+        model="gemini/gemini-2.0-flash-thinking",
+        temperature=0.2,
+    )
+
+    return Agent(
+        role="Trend Analysis Agent",
+        goal=(
+            "Digest Cleaned_Content_Stream payloads and produce an Identified_Trends_Report "
+            "summarising potential topic clusters, their momentum, sentiment profile and KOLs."
+        ),
+        backstory=(
+            "You are a quantitative trend spotter specialising in emerging Reddit discourse. "
+            "You excel at semantic clustering, temporal analysis and identifying early signals. "
+            "Always transform observations into structured data that conforms to the "
+            "IdentifiedTrendsReport schema. Use the dataset lookup tool whenever you need "
+            "to inspect specific posts referenced by post_id."
+        ),
+        llm=llm,
+        tools=[reddit_dataset_lookup_tool],
+        allow_delegation=False,
+        verbose=True,
+    )
+
+
+def build_brand_alignment_agent() -> Agent:
+    """Create the Brand Alignment Agent responsible for scoring opportunities."""
+
+    llm = LLM(
+        model="gemini/gemini-2.0-flash",
+        temperature=0.15,
+    )
+
+    return Agent(
+        role="Brand Alignment Agent",
+        goal=(
+            "Evaluate trend clusters against the Brand Core Knowledge Base and output a "
+            "Scored_And_Filtered_Opportunities list ranked by relevance, ICP fit and risk."
+        ),
+        backstory=(
+            "You are the strategic gatekeeper for JustKa AI. You absorb the brand knowledge "
+            "base, interpret relevance through the lens of ICP, funnel stage and risk, and "
+            "articulate your assessment within the ScoredAndFilteredOpportunities schema. "
+            "Use the dataset lookup tool to pull representative Reddit posts for deeper "
+            "audience analysis before finalising scores."
+        ),
+        llm=llm,
+        tools=[reddit_dataset_lookup_tool],
+        allow_delegation=False,
+        verbose=True,
+    )
+
+
+def build_topic_curator_agent() -> Agent:
+    """Create the Topic Curator Agent that packages final production briefs."""
+
+    llm = LLM(
+        model="gemini/gemini-2.0-pro",
+        temperature=0.35,
+    )
+
+    return Agent(
+        role="Topic Curator Agent",
+        goal=(
+            "Select the highest leverage opportunities and turn them into Prioritized_Topic_Brief "
+            "packages with compelling editorial angles."
+        ),
+        backstory=(
+            "You operate like a chief editor who understands growth marketing. You balance "
+            "brand fit, funnel intent and trend momentum to select 1-3 standout opportunities. "
+            "For each, craft 3-5 angles and capture supporting insights exactly as required by "
+            "the PrioritizedTopicBrief schema."
+        ),
+        llm=llm,
+        tools=[],
         allow_delegation=False,
         verbose=True,
     )

--- a/crews/content_opportunity_pipeline/schemas.py
+++ b/crews/content_opportunity_pipeline/schemas.py
@@ -1,0 +1,108 @@
+"""Pydantic schemas for structured outputs within the Content Opportunity Pipeline."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class TrendCluster(BaseModel):
+    """Representation of a clustered Reddit discussion trend."""
+
+    cluster_id: str = Field(..., description="Stable identifier for the topic cluster")
+    core_keywords: List[str] = Field(..., description="Representative keywords or n-grams that define the cluster")
+    representative_post_ids: List[str] = Field(
+        ..., description="Post identifiers that exemplify the topic cluster"
+    )
+    sentiment_label: str = Field(
+        ..., description="Sentiment classification such as Positive, Negative, Neutral or Controversial"
+    )
+    trend_velocity: float = Field(
+        ..., description="First derivative of conversation volume – how fast interest is growing"
+    )
+    trend_acceleration: float = Field(
+        ..., description="Second derivative of conversation volume to surface emerging breakouts"
+    )
+    key_opinion_leaders: List[str] = Field(
+        default_factory=list, description="High influence authors driving the conversation"
+    )
+    lifecycle_stage: str = Field(
+        ..., description="Lifecycle stage label (Nascent, Emerging, Mature, Decaying)"
+    )
+
+
+class IdentifiedTrendsReport(BaseModel):
+    """Report emitted by the Trend Analysis Agent."""
+
+    dataset_id: str = Field(..., description="Reference to the Cleaned_Content_Stream dataset backing the clusters")
+    generated_at: datetime = Field(
+        default_factory=datetime.utcnow, description="Timestamp when the report was assembled"
+    )
+    clusters: List[TrendCluster] = Field(..., description="Collection of identified topic clusters")
+
+
+class ScoredOpportunity(BaseModel):
+    """Topic opportunity annotated by the Brand Alignment Agent."""
+
+    cluster_id: str = Field(..., description="Identifier of the originating trend cluster")
+    core_keywords: List[str] = Field(..., description="Representative keywords from the originating cluster")
+    representative_post_ids: List[str] = Field(..., description="Anchoring posts for context retrieval")
+    sentiment_label: str = Field(..., description="Sentiment inherited from the trend analysis stage")
+    trend_velocity: float = Field(..., description="Velocity value inherited from the trend analysis stage")
+    trend_acceleration: float = Field(..., description="Acceleration value inherited from the trend analysis stage")
+    key_opinion_leaders: List[str] = Field(
+        default_factory=list, description="Influential voices in the conversation"
+    )
+    lifecycle_stage: str = Field(..., description="Lifecycle stage inherited from the trend analysis stage")
+    relevance_score: float = Field(
+        ..., description="Alignment score between the topic and the brand's core domains"
+    )
+    audience_alignment_score: float = Field(
+        ..., description="Fit with the ideal customer persona derived from participant analysis"
+    )
+    funnel_stage: str = Field(..., description="TOFU/MOFU/BOFU stage placement for the opportunity")
+    risk_level: str = Field(..., description="Qualitative risk rating such as Low, Medium, High")
+
+
+class ScoredAndFilteredOpportunities(BaseModel):
+    """Sorted shortlist of opportunities ready for editorial review."""
+
+    source_report_id: str = Field(..., description="Identifier for the originating trend report")
+    dataset_id: str = Field(..., description="Dataset reference so downstream agents can fetch raw posts")
+    opportunities: List[ScoredOpportunity] = Field(
+        ..., description="Opportunities ordered by brand relevance and strategic value"
+    )
+
+
+class PrioritizedTopicBriefEntry(BaseModel):
+    """Final packaged brief ready for production planning."""
+
+    topic_title: str = Field(..., description="Human friendly headline for the content opportunity")
+    recommended_angles: List[str] = Field(
+        ..., description="3-5 distinct angles tailored to the brand voice"
+    )
+    target_funnel_stage: str = Field(..., description="Selected funnel stage focus for the content piece")
+    key_insights: List[str] = Field(
+        ..., description="Supporting analytical insights such as sentiment, KOLs or statistics"
+    )
+    reference_links: List[str] = Field(
+        default_factory=list, description="Links to representative Reddit discussions or external sources"
+    )
+    strategic_priority_score: float = Field(
+        ..., description="Composite prioritisation score balancing momentum, fit and urgency"
+    )
+
+
+class PrioritizedTopicBrief(BaseModel):
+    """Top level structure produced by the Topic Curator Agent."""
+
+    generated_at: datetime = Field(
+        default_factory=datetime.utcnow, description="Timestamp when the brief was generated"
+    )
+    source_opportunity_reference: str = Field(
+        ..., description="Identifier for the scored opportunity list powering this brief"
+    )
+    selected_topics: List[PrioritizedTopicBriefEntry] = Field(
+        ..., description="Ranked list of topics approved for immediate production"
+    )


### PR DESCRIPTION
## Summary
- add dedicated pydantic schemas that formalise the trend, opportunity and topic brief hand-offs
- expand the toolset with a reddit_dataset_lookup utility for post-level retrieval from stored datasets
- introduce builder functions for the Trend Analysis, Brand Alignment and Topic Curator agents and update the module README documentation

## Testing
- python -m compileall crews/content_opportunity_pipeline

------
https://chatgpt.com/codex/tasks/task_e_68e3fddf1c488332b289b44b169a8e5a