### PR TITLE
Refactor writing crew into multi-agent viral content workflow

### DIFF
--- a/Default_Tasks1.YML
+++ b/Default_Tasks1.YML
@@ -63,21 +63,24 @@ metadata:
   description: >-
     啟動 Writing Agent，載入最新的內容機會管線輸出，根據指定平台風格改寫成準備上線的貼文。
 prompt: |
-  你是 JustKa AI 的內容改寫專家，負責把 Content Opportunity Pipeline 的結論轉化為
-  指定平台的成品文案。請依照以下流程執行：
+  你將指揮四位專家（Strategy Director、Hook Architect、Lead Conversion Writer、Editorial Guardian），
+  把 Content Opportunity Pipeline 的洞察轉化為爆文級成品，並沿用《DR_爆文生產系統性方法研究》的框架：
 
-  1. 解析指令：檢視 operator 的 rewrite 要求（若無則以 {{default_rewrite_platform}} 風格為預設）。
-  2. 熟悉背景：閱讀 `pipeline_context` 提供的趨勢報告、品牌機會與策展簡報，理解
-     選題理由、核心訊息與風險備註。
-  3. 追溯資料：如需引用 Reddit 原文，使用 `content_explorer` 搭配 `dataset_id` 抽取貼文與留言，
-     確認數據真實性與語意脈絡。
-  4. 取得風格指引：視需求呼叫 `facebook_writer`、`x_writer` 或 `thread_writer` 工具，理解平台
-     著重的語氣、結構、CTA 形式。
-  5. 完成立交付：產出符合 WritingAgentOutput schema 的 JSON，至少包含一個 rewrite 變體，
-     並列出支撐重點、引用連結與給編輯團隊的注意事項。
+  1. **策略鋪陳**：Strategy Director 需挑選最契合 '{{user_request}}' 的 brief，萃取受眾痛點、品牌承諾與資料佐證，
+     並明確標記 STEPPS 與資訊差、FOMO、預期心理、社會認同等進階心理觸發器的運用方式。
+  2. **Hook 設計**：Hook Architect 將藍圖轉譯成多平台可用的 Hook 與敘事節奏，預設至少涵蓋 {{default_rewrite_platform}} 與一個次要平台，
+     每個 Hook 都需說明觸發器堆疊與引用的資料洞察，必要時呼叫 `facebook_writer`、`x_writer`、`thread_writer` 取得語氣指引。
+  3. **成品撰寫**：Lead Conversion Writer 依策略撰寫符合 WritingAgentOutput schema 的成品。每個 rewrite 必須：
+     - 延續策略藍圖的故事弧；
+     - 在 supporting_points 中標示數據或留言證據；
+     - 在 references 中提供 dataset_id + post_id 或 permalink；
+     - 在 editorial_notes 中列出假設、風險、建議 KPI 或後續行動。
+  4. **品質保證**：Editorial Guardian 最終審查並補上 quality_review，確認觸發器確實落地、語氣符合「更智慧、更省力、更美好」，
+     且所有引用可追溯。
 
-  請主動列出假設與風險（例如資料時效、需二次審稿的敏感措辭），確保文本符合 JustKa AI
-  的品牌語調「更智慧、更省力、更美好」。
+  避免貼上冗長原始 JSON；僅在需要時用工具抓取重點並以摘要呈現。最終輸出務必是符合 WritingAgentOutput 的 JSON，
+  並帶有 strategic_blueprint、hook_concepts、quality_review 欄位供後續追溯。若 operator 未指定平台，優先完成 {{default_rewrite_platform}}，
+  但可視策略補寫其他高潛力通路。
 
 ---
 agent: reddit_scraper
@@ -176,10 +179,12 @@ metadata:
   description: >-
     先看 brief 再下筆，缺料就用 post_id 補。
 prompt: |
-  重點：只讀 `prioritized_topic_briefs` + `scored_and_filtered_opportunities`。
-  先挑 1 個 brief，從 reference_links 選 2-3 個 post_id，用 content_explorer(normalized)抓素材。
-  依 {{default_rewrite_platform}} 風格寫一版，附 CTA、supporting_points、references（用 permalink）。
-  用 WritingAgentOutput JSON 返回。
+  Focus 模式：只使用 `prioritized_topic_briefs` 與 `scored_and_filtered_opportunities` 內的資料。
+  讓 Strategy Director 鎖定 1 個最有價值的 brief，必要時用 content_explorer(normalized) 從 reference_links 中抓 2-3 個 post_id 核實證據。
+  Hook Architect 需針對 {{default_rewrite_platform}} 提供至少兩個 HookConcept，說明觸發器堆疊與資料佐證。
+  Lead Conversion Writer 只需完成 {{default_rewrite_platform}} 平台的 rewrite，但仍須保留 strategic_blueprint、hook_concepts。
+  Editorial Guardian 應在 quality_review 中紀錄任何未覆蓋的資料缺口或待補素材。
+  最終以 WritingAgentOutput JSON 輸出，含 CTA、supporting_points、references（優先 permalink 或 dataset_id+post_id）、editorial_notes。
 
 ---
 agent: writing_agent
@@ -193,10 +198,12 @@ metadata:
   description: >-
     先出 X 線程，再給 FB 短稿，一次兩版。
 prompt: |
-  選 1 個 brief：
-  - 從 reference_links 抽 2 個 post_id，用 content_explorer(normalized) 驗證與摘錄。
-  - 先寫 X 線程（開場1句＋3-5點），再寫 FB 版短稿（1段＋CTA）。
-  - 每版都附 references 與 editorial_notes。用 WritingAgentOutput JSON 返回。
+  選定 1 個 brief 後：
+  - Strategy Director 確保故事骨幹能同時支援 X 線程與 Facebook 短稿，必要時補抓原始留言或數據。
+  - Hook Architect 為兩個平台分別設計 HookConcept：X 線程須有開場鉤子＋3-5 條節奏；Facebook 短稿須有單段敘事＋CTA。
+  - Lead Conversion Writer 產出兩個 rewrite 變體：第一個為 X thread（首句＋條列）、第二個為 Facebook 貼文（短段＋CTA）。
+  - Editorial Guardian 需確認每個平台都啟用至少兩種心理觸發器（例如 情緒 + 實用價值）並於 quality_review 註記。
+  返回符合 WritingAgentOutput 的 JSON，為每個變體提供 supporting_points、references、editorial_notes。
 
 ---
 agent: writing_agent
@@ -210,7 +217,9 @@ metadata:
   description: >-
     低 token 單題單平台：穩、準、可追溯。
 prompt: |
-  低 Token 模式：只處理 1 個 brief、只輸出 1 個平台（{{default_rewrite_platform}}）。
-  不先塞大段上下文；需要引用才用 post_id + content_explorer(normalized) 抓原文。
-  產出正文＋CTA，附 supporting_points、references（permalink 或 post_id）、editorial_notes（含風險假設）。
-  嚴格用 WritingAgentOutput JSON 返回。
+  低 Token 模式：
+  - Strategy Director 以極簡字數描述受眾張力、品牌承諾與必備證據（最多 3 條 supporting data）。
+  - Hook Architect 僅提交 1 個精煉 HookConcept，聚焦 {{default_rewrite_platform}}，並註明使用的關鍵觸發器。
+  - Lead Conversion Writer 只輸出 {{default_rewrite_platform}} 單一 rewrite（正文＋CTA），確保 supporting_points、references、editorial_notes 精簡但可追溯。
+  - Editorial Guardian 在 quality_review 中列出合規檢查與任何需要人審的紅旗。
+  禁止貼上大段原文；如需引用請以 paraphrase + permalink/post_id 呈現。最終以 WritingAgentOutput JSON 返回。

--- a/crews/writing_agent/__init__.py
+++ b/crews/writing_agent/__init__.py
@@ -1,8 +1,20 @@
 """Writing Agent package."""
 
 from .crew import WritingAgentCrew
-from .agents import build_writing_agent
-from .tasks import build_writing_task
+from .agents import (
+    build_editor_in_chief_agent,
+    build_editorial_guardian_agent,
+    build_hook_architect_agent,
+    build_master_writer_agent,
+    build_writing_agent,
+    build_writing_team,
+)
+from .tasks import (
+    build_hook_task,
+    build_quality_task,
+    build_strategy_task,
+    build_writing_task,
+)
 from .tools import (
     facebook_writer_tool,
     thread_writer_tool,
@@ -11,7 +23,15 @@ from .tools import (
 
 __all__ = [
     "WritingAgentCrew",
+    "build_editor_in_chief_agent",
+    "build_editorial_guardian_agent",
+    "build_hook_architect_agent",
+    "build_master_writer_agent",
     "build_writing_agent",
+    "build_writing_team",
+    "build_strategy_task",
+    "build_hook_task",
+    "build_quality_task",
     "build_writing_task",
     "facebook_writer_tool",
     "x_writer_tool",

--- a/crews/writing_agent/agents.py
+++ b/crews/writing_agent/agents.py
@@ -1,6 +1,8 @@
 """Agent definitions for the Writing Agent crew."""
 from __future__ import annotations
 
+from typing import Dict
+
 from crewai import Agent
 from crewai.llm import LLM
 
@@ -17,28 +19,49 @@ from .tools import (
 ensure_gemini_rate_limit()
 
 
-def build_writing_agent() -> Agent:
-    """Create the Writing Agent responsible for platform-specific rewrites."""
-
-    llm = LLM(
+def _build_llm(temperature: float) -> LLM:
+    return LLM(
         model="gemini/gemini-2.5-flash",
-        temperature=0.35,
+        temperature=temperature,
     )
 
+
+def build_editor_in_chief_agent() -> Agent:
+    """Agent that digests briefs and crafts the strategic blueprint."""
+
     return Agent(
-        role="Content Writing Agent",
+        role="Editorial Strategy Director",
         goal=(
-            "Transform validated opportunities into channel-ready copy while preserving brand promises, "
-            "data fidelity and risk guardrails."
+            "Translate prioritized_topic_briefs into a strategic blueprint that encodes STEPPS triggers, "
+            "audience psychology and verifiable proof points so downstream writers can execute flawlessly."
         ),
         backstory=(
-            "You are the finishing specialist for the Content Opportunity Pipeline. You ingest structured "
-            "trend, opportunity and brief artifacts, inspect underpinning Reddit posts via dataset lookup "
-            "tools, and craft production-ready drafts tuned to the requested platform style. You handle "
-            "ambiguity by clarifying assumptions, ensure factual claims remain traceable to the dataset_id, "
-            "and document editorial notes for downstream reviewers."
+            "You are a newsroom editor trained in behavioural science and viral growth systems. You map "
+            "audience tensions to brand promises, insist on dataset-backed evidence and de-risk topics before "
+            "they reach production. Your work references the DR_爆文生產系統性方法研究 playbook."
         ),
-        llm=llm,
+        llm=_build_llm(temperature=0.2),
+        tools=[content_explorer_tool],
+        allow_delegation=False,
+        verbose=True,
+    )
+
+
+def build_hook_architect_agent() -> Agent:
+    """Agent that transforms the blueprint into scroll-stopping hooks."""
+
+    return Agent(
+        role="Hook and Narrative Architect",
+        goal=(
+            "Design multi-platform hooks and outline beats that combine STEPPS with advanced triggers such as "
+            "信息差、FOMO 和預期心理, ensuring each idea ladders back to the strategic blueprint."
+        ),
+        backstory=(
+            "You specialise in viral copy systems. You remix the blueprint into specific hooks, cross-channel "
+            "story arcs and CTA ladders. You are fluent in the DR viral framework and know how to keep tokens "
+            "lean by working from distilled insights."
+        ),
+        llm=_build_llm(temperature=0.35),
         tools=[
             content_explorer_tool,
             facebook_writer_tool,
@@ -50,4 +73,73 @@ def build_writing_agent() -> Agent:
     )
 
 
-__all__ = ["build_writing_agent"]
+def build_master_writer_agent() -> Agent:
+    """Agent that crafts production-ready long/short-form rewrites."""
+
+    return Agent(
+        role="Lead Conversion Writer",
+        goal=(
+            "Craft channel-ready drafts that activate the agreed trigger stack, protect factual integrity and "
+            "package the story arc into irresistible copy tailored to each platform."
+        ),
+        backstory=(
+            "You are the closer. You turn blueprints into polished drafts while citing dataset evidence, "
+            "balancing emotional payoff with practical value. You maintain the brand promise '更智慧、更省力、更美好'."
+        ),
+        llm=_build_llm(temperature=0.45),
+        tools=[
+            content_explorer_tool,
+            facebook_writer_tool,
+            x_writer_tool,
+            thread_writer_tool,
+        ],
+        allow_delegation=False,
+        verbose=True,
+    )
+
+
+def build_editorial_guardian_agent() -> Agent:
+    """Agent that performs final QA and risk mitigation."""
+
+    return Agent(
+        role="Editorial Guardian",
+        goal=(
+            "Stress-test the draft against brand guardrails, ensure claims are traceable to dataset_id and "
+            "append a concise QA report with improvement notes."
+        ),
+        backstory=(
+            "You audit final outputs for factuality, compliance and persuasive completeness. You cross-check "
+            "the trigger stack, verify citations and flag mitigation steps."
+        ),
+        llm=_build_llm(temperature=0.15),
+        tools=[content_explorer_tool],
+        allow_delegation=False,
+        verbose=True,
+    )
+
+
+def build_writing_team() -> Dict[str, Agent]:
+    """Return the full team of agents collaborating on the writing workflow."""
+
+    return {
+        "editor_in_chief": build_editor_in_chief_agent(),
+        "hook_architect": build_hook_architect_agent(),
+        "master_writer": build_master_writer_agent(),
+        "editorial_guardian": build_editorial_guardian_agent(),
+    }
+
+
+def build_writing_agent() -> Agent:
+    """Backward compatible helper returning the master writer agent."""
+
+    return build_master_writer_agent()
+
+
+__all__ = [
+    "build_editor_in_chief_agent",
+    "build_hook_architect_agent",
+    "build_master_writer_agent",
+    "build_editorial_guardian_agent",
+    "build_writing_team",
+    "build_writing_agent",
+]

--- a/crews/writing_agent/schemas.py
+++ b/crews/writing_agent/schemas.py
@@ -6,6 +6,102 @@ from typing import List, Optional
 from pydantic import BaseModel, Field
 
 
+class ViralFrameworkApplication(BaseModel):
+    """How a persuasion or virality framework is applied in the piece."""
+
+    framework: str = Field(
+        ..., description="Name of the persuasion/virality framework being invoked"
+    )
+    objective: str = Field(
+        ..., description="The communication goal this framework reinforces"
+    )
+    execution: str = Field(
+        ..., description="Concrete copy or structural choice that applies the framework"
+    )
+
+
+class EditorialRisk(BaseModel):
+    """Potential brand, factual or compliance risk surfaced by reviewers."""
+
+    risk: str = Field(..., description="Short description of the potential risk")
+    severity: str = Field(
+        ..., description="Qualitative severity (e.g. low/medium/high) with justification"
+    )
+    mitigation_plan: str = Field(
+        ..., description="Recommended mitigation or follow-up action"
+    )
+
+
+class StrategicBlueprint(BaseModel):
+    """Upstream briefing that grounds the eventual rewrite."""
+
+    selected_brief_title: str = Field(
+        ..., description="Title or topic of the prioritized brief powering this rewrite"
+    )
+    audience_insight: str = Field(
+        ..., description="Succinct description of the audience tension or desire"
+    )
+    brand_promise: str = Field(
+        ..., description="How the brand resolves the tension in line with its positioning"
+    )
+    key_data_points: List[str] = Field(
+        default_factory=list,
+        description="Quantitative or qualitative proof points lifted from the dataset",
+    )
+    psychological_triggers: List[str] = Field(
+        default_factory=list,
+        description="List of STEPPS/advanced triggers intentionally activated",
+    )
+    story_arc: List[str] = Field(
+        default_factory=list,
+        description="Ordered outline beats that will structure the narrative",
+    )
+    framework_applications: List[ViralFrameworkApplication] = Field(
+        default_factory=list,
+        description="How specific persuasion frameworks will materialise inside the copy",
+    )
+    editorial_risks: List[EditorialRisk] = Field(
+        default_factory=list,
+        description="Known risks the downstream writer and editor must monitor",
+    )
+
+
+class HookConcept(BaseModel):
+    """A platform-ready hook or angle derived from the blueprint."""
+
+    platform: str = Field(
+        ..., description="Channel or format the hook is optimised for"
+    )
+    hook: str = Field(..., description="Scroll-stopping hook, headline or opening line")
+    supporting_promise: str = Field(
+        ..., description="What payoff the hook promises to the audience"
+    )
+    trigger_stack: List[str] = Field(
+        default_factory=list,
+        description="Psychological triggers blended inside this hook",
+    )
+    validation_notes: Optional[str] = Field(
+        None,
+        description="Why this hook should resonate, referencing dataset observations",
+    )
+
+
+class QualityReview(BaseModel):
+    """Final self-check applied to the finished rewrite."""
+
+    compliance_checks: List[str] = Field(
+        default_factory=list,
+        description="Confirmed guardrails (facts verified, brand taboos avoided)",
+    )
+    improvement_notes: List[str] = Field(
+        default_factory=list,
+        description="Actionable follow-ups for human editors or distribution teams",
+    )
+    confidence_rating: str = Field(
+        ..., description="Overall confidence statement with rationale"
+    )
+
+
 class RewriteVariant(BaseModel):
     """Represents a single platform-specific rewrite of the brief."""
 
@@ -51,6 +147,26 @@ class WritingAgentOutput(BaseModel):
         default_factory=list,
         description="Additional notes or considerations for downstream editorial teams",
     )
+    strategic_blueprint: Optional[StrategicBlueprint] = Field(
+        None,
+        description="Upstream strategic plan that guided the draft",
+    )
+    hook_concepts: List[HookConcept] = Field(
+        default_factory=list,
+        description="Collection of shortlisted hooks or openings for each platform",
+    )
+    quality_review: Optional[QualityReview] = Field(
+        None,
+        description="Final QA assessment appended by the editorial guardian",
+    )
 
 
-__all__ = ["RewriteVariant", "WritingAgentOutput"]
+__all__ = [
+    "ViralFrameworkApplication",
+    "EditorialRisk",
+    "StrategicBlueprint",
+    "HookConcept",
+    "QualityReview",
+    "RewriteVariant",
+    "WritingAgentOutput",
+]

--- a/crews/writing_agent/tasks.py
+++ b/crews/writing_agent/tasks.py
@@ -3,30 +3,97 @@ from __future__ import annotations
 
 from crewai import Task
 
-from .schemas import WritingAgentOutput
+from .schemas import HookConcept, StrategicBlueprint, WritingAgentOutput
 
 
-def build_writing_task(agent) -> Task:
-    """Task guiding the Writing Agent to produce platform-ready rewrites."""
+def build_strategy_task(agent) -> Task:
+    """Digest briefs and produce a DR-aligned strategic blueprint."""
 
     return Task(
         description=(
-            "Review the condensed context inside '{{pipeline_context}}'. Use the summarized "
-            "'scored_and_filtered_opportunities' for strategic positioning and the "
-            "'prioritized_topic_briefs' to determine concrete writing tasks. If '{{dataset_id}}' "
-            "is provided, call the content_explorer tool with specific post_ids from the briefs' "
-            "reference_links to verify quotes and extract material. Apply the rewrite instructions "
-            "from '{{user_request}}' (or use the default style guidance when unspecified) and craft "
-            "channel-ready copy."
+            "研讀 '{{pipeline_context}}' 中的 prioritized_topic_briefs 與 scored_and_filtered_opportunities，"  # noqa: E501
+            "挑選最符合 '{{user_request}}' 指示的單一 brief。建立一份 Strategic Blueprint："  # noqa: E501
+            "闡述目標受眾的痛點、品牌承諾、核心故事骨幹，以及你會啟用的 STEPPS 與進階心理觸發器（資訊差、FOMO、預期心理、社會認同等）。"  # noqa: E501
+            "引用 dataset_id 可追溯的證據，必要時呼叫 content_explorer_tool 取得貼文或留言原文。"  # noqa: E501
+            "同時列出潛在的編輯風險與緩解策略，確保後續寫作有依可循。"
         ),
         expected_output=(
-            "Return JSON that conforms to the WritingAgentOutput schema, including platform-specific rewrites, "
-            "supporting references and editorial notes for downstream editors."
+            "輸出 StrategicBlueprint JSON，包含已選 brief 標題、受眾洞察、品牌承諾、故事節點、"  # noqa: E501
+            "框架應用與風險備註。"
         ),
         agent=agent,
+        async_execution=False,
+        output_json_schema=StrategicBlueprint.model_json_schema(),
+    )
+
+
+def build_hook_task(agent, strategy_task: Task) -> Task:
+    """Create cross-platform hooks and trigger stacks based on the blueprint."""
+
+    return Task(
+        description=(
+            "根據策略藍圖（context 中的 StrategicBlueprint）與 '{{user_request}}'，"  # noqa: E501
+            "設計多平台可用的 Hook 與敘事節奏。除非指令明確要求精簡，預設至少提供兩個 Hook。每個 Hook 需清楚說明吸睛句、承諾的價值、"  # noqa: E501
+            "對應的心理觸發器堆疊，以及引用的資料洞察。視需求呼叫 facebook_writer、x_writer、thread_writer 工具取得語氣指引。"  # noqa: E501
+            "保持精煉，避免無意義的長篇鋪陳。"
+        ),
+        expected_output=(
+            "輸出 HookConcept JSON 陣列，每個元素包含 hook 文案、觸發器組合、支撐承諾的資料觀察與適用平台。"
+        ),
+        agent=agent,
+        context=[strategy_task],
+        async_execution=False,
+        output_json_schema={
+            "type": "array",
+            "items": HookConcept.model_json_schema(),
+        },
+    )
+
+
+def build_writing_task(agent, strategy_task: Task, hook_task: Task) -> Task:
+    """Produce channel-ready drafts using the upstream assets."""
+
+    return Task(
+        description=(
+            "閱讀 context 內的 StrategicBlueprint 與 HookConcept 清單。遵照 '{{user_request}}' 指示的主要平台，"  # noqa: E501
+            "必要時加開其他高影響力平台。撰寫符合 WritingAgentOutput schema 的成品："  # noqa: E501
+            "1) 每個 rewrite 需延續策略藍圖的故事弧；2) 明確引用 dataset_id + post_id 或 permalink；"  # noqa: E501
+            "3) supporting_points 要點出數據或洞察來源；4) editorial_notes 紀錄假設、待審風險、建議 KPI。"  # noqa: E501
+            "輸出時一併附上 strategic_blueprint 與 hook_concepts 以便追溯。"
+        ),
+        expected_output=(
+            "回傳符合 WritingAgentOutput 的 JSON，至少 1 個 rewrite 變體，並整合 strategic_blueprint 與 hook_concepts。"
+        ),
+        agent=agent,
+        context=[strategy_task, hook_task],
         async_execution=False,
         output_json_schema=WritingAgentOutput.model_json_schema(),
     )
 
 
-__all__ = ["build_writing_task"]
+def build_quality_task(agent, strategy_task: Task, hook_task: Task, writing_task: Task) -> Task:
+    """Perform a final QA pass and append the quality review to the output."""
+
+    return Task(
+        description=(
+            "審閱 context 中的 WritingAgentOutput，對照 StrategicBlueprint 與 HookConcept 確認："  # noqa: E501
+            "心理觸發器是否落實、引用是否可追溯、品牌語氣是否一致。必要時可微調文案強化說服力，"  # noqa: E501
+            "但請保留原作者意圖並記錄變更理由。最後輸出更新後的 WritingAgentOutput，並填寫 quality_review："  # noqa: E501
+            "列出已完成的合規檢查、給人類編輯的改善建議與整體信心評分。"
+        ),
+        expected_output=(
+            "輸出最終版 WritingAgentOutput JSON（含 quality_review）。若有調整請在 editorial_notes 裡說明。"
+        ),
+        agent=agent,
+        context=[strategy_task, hook_task, writing_task],
+        async_execution=False,
+        output_json_schema=WritingAgentOutput.model_json_schema(),
+    )
+
+
+__all__ = [
+    "build_strategy_task",
+    "build_hook_task",
+    "build_writing_task",
+    "build_quality_task",
+]


### PR DESCRIPTION
## Summary
- refactor the writing crew into a four-agent workflow that adds strategic blueprinting, hook generation, execution, and QA stages aligned with the DR viral framework
- expand the writing agent schemas and default prompts to capture strategic blueprints, hook concepts, and quality reviews for stronger traceability

## Testing
- python -m compileall crews/writing_agent

------
https://chatgpt.com/codex/tasks/task_e_68e56621f6248332b7b525e755c93945